### PR TITLE
Kuk/4월1주차/3문제

### DIFF
--- a/cpp/divideToPlus.cpp
+++ b/cpp/divideToPlus.cpp
@@ -1,0 +1,39 @@
+#include <iostream>
+using namespace std;
+
+int MOD = 1000000000;
+
+int main()
+{
+    cin.tie(NULL); cout.tie(NULL);
+    ios::sync_with_stdio(false);
+
+    int N, K;
+    cin >> N >> K;
+
+    // dp[현재 숫자][남은 카운트]
+    // dp[0][k] = 1(k >= 1)
+    // dp[n][1] = 1
+    // dp[n][k] = dp[n][k - 1] + dp[n - 1][k - 1] + ... dp[0][k - 1]
+
+    int dp[201][201] = {0, };
+    for (int i=1; i<=K; ++i)
+        dp[0][i] = 1;
+
+    for (int i=0; i<=N; ++i)
+        dp[i][1] = 1;
+
+    for (int n=1; n<=N; ++n)
+    {
+        for (int k=2; k<=K; ++k)
+        {
+            for (int s=0; s<=n; ++s)
+            {
+                dp[n][k] = (dp[n][k] + dp[n - s][k - 1]) % MOD;
+                // dp[n][k] = (dp[n][k] + dp[s][k - 1]) % MOD;
+            }
+        }
+    }
+
+    cout << dp[N][K];
+}

--- a/cpp/meetings.cpp
+++ b/cpp/meetings.cpp
@@ -1,0 +1,53 @@
+#include <iostream>
+#include <vector>
+#include <algorithm>
+using namespace std;
+
+bool mycmp(pair<int, int> a, pair<int, int> b)
+{
+    /*
+    반례
+    3
+    4 4
+    3 4
+    2 4
+    */
+   if (a.second == b.second) return a.first < b.first;
+   return a.second < b.second;
+}
+
+int main()
+{
+   cin.tie(NULL); cout.tie(NULL);
+   ios::sync_with_stdio(false);
+
+    // 시작 시간 vs 종료 시간
+    // 그냥 무조건 끝나는 시간 빠른거 하는게 이득 아님?
+
+   int n; cin >> n;
+   vector<pair<int, int>> meetings(n);
+   for (auto& e : meetings)
+   {
+      cin >> e.first >> e.second;
+   }
+
+   sort(meetings.begin(), meetings.end(), mycmp);
+   /*for (auto& e : meetings)
+   {
+      cout << e.first << ' ' << e.second << '\n';
+   }*/
+
+   int result = 1;
+   int start = meetings[0].first;
+   int end = meetings[0].second;
+   for (int i = 1; i < meetings.size(); ++i)
+   {
+      if (meetings[i].first < end) continue;
+
+      start = meetings[i].first;
+      end = meetings[i].second;
+      result += 1;
+   }
+
+   cout << result;
+}

--- a/cpp/rgbDistance2.cpp
+++ b/cpp/rgbDistance2.cpp
@@ -1,0 +1,41 @@
+#include <iostream>
+using namespace std;
+
+int main()
+{
+    cin.tie(NULL); cout.tie(NULL);
+    ios::sync_with_stdio(false);
+
+    int n; cin >> n;
+    int prices[1001][3];
+    for (int i=1; i<=n; ++i)
+        for (int j=0; j<3; ++j)
+            cin >> prices[i][j];
+
+    // dp[a][b] : a번째 집의 b번째를 칠하는 비용 중 최솟값
+    int dp[1001][3];
+    int result = 987654321;
+    for (int start = 0; start < 3; ++start)
+    {
+        for (int i=0; i<3; ++i)
+        {
+            if (i == start) dp[1][i] = prices[1][i];
+            else dp[1][i] = 987654321;
+        }
+
+        for (int i=2; i<=n; ++i)
+        {
+            dp[i][0] = min(dp[i-1][1], dp[i-1][2]) + prices[i][0];
+            dp[i][1] = min(dp[i-1][0], dp[i-1][2]) + prices[i][1];
+            dp[i][2] = min(dp[i-1][0], dp[i-1][1]) + prices[i][2];
+        }
+
+        for (int end=0; end<3; ++end)
+        {
+            if (start != end)
+                result = min(result, dp[n][end]);
+        }
+    }
+
+    cout << result;
+}


### PR DESCRIPTION
## 문제 : 1931 회의실 배정
### 알고리즘 : 그리디

입력값을 정렬해야 할 것 같은 느낌이 바로 들었는데 시작 시간을 기준으로 할 지 끝나는 시간을 기준으로 할 지가 문제였다.

시작 시간이 아무리 빨라도 끝나는 시간이 늦어버리면 그 사이의 회의를 하나도 잡지 못하기 때문에 끝나는 시간 기준으로 하는게 맞았고 그렇게 정렬해서 풀기를 시도했다.

단순히 끝나는 시간의 오름차순으로 배열을 정렬하니 반례가 생겼는데 끝나는 시간이 만약 동일한 경우, 이때는 시작 시간이 빠른 순으로 오름차순 정렬하는 것이 맞았다.

**결론**
1. 끝나는 시간으로 오름차순 정렬
2. 끝나는 시간이 같은 경우 시작 시간으로 오름차순
3. 그 후에는 루프 돌며 조건 맞게 카운트


