### PR TITLE
7월5주차 / 4문제

### DIFF
--- a/cpp/ClimbingStairs.cpp
+++ b/cpp/ClimbingStairs.cpp
@@ -1,0 +1,21 @@
+// LEET 70. Climbing Stairs
+#include <iostream>
+#include <vector>
+using namespace std;
+
+class Solution {
+public:
+    int climbStairs(int n) {
+        int dp[46];
+        dp[1] = 1;
+        dp[2] = 2;
+        // dp[n] = dp[n - 1] + dp[n - 2]
+
+        for (int i=3; i<=n; ++i)
+        {
+            dp[i] = dp[i-1] + dp[i-2];
+        }
+
+        return dp[n];
+    }
+};

--- a/cpp/LongestIncreasingSubsequence.cpp
+++ b/cpp/LongestIncreasingSubsequence.cpp
@@ -1,0 +1,57 @@
+// LEET 300. Longest Increasing Subsequence
+#include <iostream>
+#include <vector>
+using namespace std;
+
+class Solution {
+public:
+    int lowerBound(vector<int>& arr, int target)
+    {
+        int low = 0;
+        int high = arr.size() - 1;
+        while (low <= high)
+        {
+            int mid = (low + high) / 2;
+            if (arr[mid] < target)
+                low = mid + 1;
+            else
+                high = mid - 1;
+        }
+        return low;
+    }
+
+    int lengthOfLIS(vector<int>& nums) {
+        vector<int> arr;
+        for (auto& num : nums)
+        {
+            int idx = lowerBound(arr, num);
+            if (idx == arr.size()) arr.push_back(num);
+            else arr[idx] = num;
+        }
+        return arr.size();
+    }
+
+    // O(N^2) 풀이법
+    // int lengthOfLIS(vector<int>& nums) {
+    //     int dp[2502];
+    //     // dp[n] = dp[0~n-1]의 최댓값 + 1, 이때 nums[n]은 nums[0~n-1] 중 최댓값 보다 커야한다
+    //     for (int i=0; i<nums.size(); ++i)
+    //     {
+    //         int temp = 1;
+    //         for (int j=0; j<i; ++j)
+    //         {
+    //             if (nums[j] < nums[i])
+    //                 temp = max(temp, dp[j] + 1); // i가 j보다 크면 dp[j] + 1 하는거지
+    //         }
+    //         dp[i] = temp;
+    //     }
+
+    //     int ret = 0;
+    //     for (int i=0; i<nums.size(); ++i)
+    //     {
+    //         ret = max(ret, dp[i]);
+    //     }
+
+    //     return ret;
+    // }
+};

--- a/cpp/MinimumPathSum.cpp
+++ b/cpp/MinimumPathSum.cpp
@@ -1,0 +1,31 @@
+// LEET 64. Minimum Path Sum
+#include <iostream>
+#include <vector>
+using namespace std;
+
+class Solution {
+public:
+    int minPathSum(vector<vector<int>>& grid) {
+        int row = grid.size();
+        int col = grid[0].size();
+
+        int dp[201][201];
+        dp[0][0] = grid[0][0];
+        for (int i=1; i<row; ++i)
+            dp[i][0] = dp[i-1][0] + grid[i][0];
+        for (int i=1; i<col; ++i)
+            dp[0][i] = dp[0][i-1] + grid[0][i];
+
+        // dp[n][m] = min(dp[n - 1][m], dp[n][m - 1]) + grid[n][m];
+        for (int i=1; i<row; ++i)
+        {
+            for (int j=1; j<col; ++j)
+            {
+                dp[i][j] = min(dp[i-1][j], dp[i][j-1]) + grid[i][j];
+            }
+        }
+
+        return dp[row - 1][col - 1];
+
+    }
+};

--- a/cpp/StockIII.cpp
+++ b/cpp/StockIII.cpp
@@ -1,0 +1,34 @@
+// LEET 123. Best Time to Buy and Sell Stock III
+#include <iostream>
+#include <vector>
+using namespace std;
+
+class Solution {
+public:
+    int maxProfit(vector<int>& prices) {
+        int left[100000] = {0, };
+        int right[100000] = {0, };
+
+        int temp = prices.front();
+        for (int i=1; i<prices.size(); ++i)
+        {
+            temp = min(temp, prices[i]);
+            left[i] = max(prices[i] - temp, left[i - 1]);
+        }
+
+        temp = prices.back();
+        for (int i=prices.size() - 2; i>=0; --i)
+        {
+            temp = max(temp, prices[i]);
+            right[i] = max(right[i + 1], temp - prices[i]);
+        }
+
+        int ret = right[0];
+        for (int i=0; i<prices.size() - 1; ++i)
+        {
+            ret = max(ret, left[i] + right[i+1]);
+        }
+
+        return ret;
+    }
+};


### PR DESCRIPTION
### LEET 70. Climbing Stairs - Success

한 칸 or 두 칸 가는 경우를 0~n-1까지 DP 배열에 저장해가며
점화식 dp[n] = dp[n - 1] + dp[n - 2]  을 풀면 해결할 수 있다.

### LEET 64. Minimum Path Sum - Success

1. dp 배열 초기화
dp[0][i] = dp[0][i - 1] + grid[0][i],
dp[i][0] = dp[i - 1][0] + grid[i][0]

2. 점화식
dp[i][j] = min(dp[i][j-1], dp[i-1][j]) + grid[i][j]


### LEET 300. Longest Increasing Subsequence - Fail
종만북에서의 dp 풀이는 놔주고 더 직관적인 DP 풀이로 풀자..

- **O(N^2)** 풀이법

1. dp[n] : 0~n 범위에어의 최장 길이.
2. 점화식
dp[i] : 0~i-1 내의 j에 대해 nums[j] < nums[i] 일 때 dp[j] + 1 의 최댓값

- **O(NlogN)** 풀이법

임시 벡터 arr 를 선언하고, nums를 순회하며 arr를 업데이트하여 최장 길이일 떄의 벡터를 구한다.

nums를 순회하며 해당 element의 값이 arr의 모든 원소들보다 크다면 arr의 제일 마지막에 push_back 해준다. 
그렇지 않으면 해당 element를 target으로 arr에서 lowerBound를 찾는다(arr는 증가함수이기 때문). 그리고 그 lowerBound Index 자리를 element로 대체한다.

~-> 굉장히 신기한 풀이법~

### LEET 123. Best Time to Buy and Sell Stock III - Fail

left, right 라는 두 개의 dp 배열을 사용한다.

1. left[n] : 0~n 내에서 낼 수 있는 최대 이익
2. right[n] : n~prices.size() - 1 내에서 낼 수 있는 최대 이익

left[i] = max(left[i - 1], prices[i] - 0~i-1 중 최솟값)
right[i] = max(right[i + 1], i+1~배열끝 중 최댓값 - prices[i])

최종 결과는 left[i] + right[i + 1] 의 최댓값이다.